### PR TITLE
LTYP-110 - Support for bulleted lists (LEAN-3377)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/json-schema",
-  "version": "2.2.6-LEAN-3423-0",
+  "version": "2.2.7",
   "description": "The Manuscripts JSON Schema types, and validation functions.",
   "repository": "github:Atypon-OpenSource/manuscripts-json-schema",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/json-schema",
-  "version": "2.2.6",
+  "version": "2.2.6-LEAN-3423-0",
   "description": "The Manuscripts JSON Schema types, and validation functions.",
   "repository": "github:Atypon-OpenSource/manuscripts-json-schema",
   "license": "Apache-2.0",

--- a/schemas/concrete/MPListElement.json
+++ b/schemas/concrete/MPListElement.json
@@ -15,7 +15,7 @@
         },
         "listStyleType": {
           "type": "string",
-          "enum": ["order", "alpha-lower", "alpha-upper", "roman-lower", "roman-upper", "bullet"]
+          "enum": ["order", "alpha-lower", "alpha-upper", "roman-lower", "roman-upper", "bullet", "simple"]
         }
       },
       "required": []


### PR DESCRIPTION
Add support for the plain list type, and it will be called **simple** based on jats XML [list-type](https://jats.nlm.nih.gov/archiving/tag-library/1.1/attribute/list-type.html)